### PR TITLE
Fix StyleCI setting and coding style

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -34,7 +34,6 @@ enabled:
   - no_trailing_comma_in_list_call
   - no_trailing_comma_in_singleline_array
   - no_unneeded_control_parentheses
-  - no_unreachable_default_argument_value
   - no_unused_imports
   - no_useless_return
   - no_whitespace_before_comma_in_array
@@ -59,7 +58,6 @@ enabled:
   - phpdoc_types
   - phpdoc_var_without_name
   - print_to_echo
-  - self_accessor
   - short_array_syntax
   - short_scalar_cast
   - single_blank_line_before_namespace

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -58,7 +58,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider implements Def
             'dossierdata.email.rule.rfc_no_warnings',
             'dossierdata.email.rule.spf',
             'dossierdata.email.rule.dns',
-            'dossierdata.email.rules'
+            'dossierdata.email.rules',
         ];
     }
 }


### PR DESCRIPTION
## Description

- Removing the `no_unreachable_default_argument_value fixer` because it's not enabled on StyleCI risky mode.
- Removing the `self_accessor` fixer because it's not enabled on StyleCI mode.

## Motivation and Context

- Fixing coding style and StyleCI setting.